### PR TITLE
Add cmd to show version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help: ## prints help (only for tasks with comment)
 APP=kube-tmuxp
 SRC_PACKAGES=$(shell go list ./...)
 APP_EXECUTABLE="./out/$(APP)"
+BUILD?=$(shell git describe --tags --always --dirty)
 RICHGO=$(shell command -v richgo 2> /dev/null)
 
 ifeq ($(RICHGO),)
@@ -22,10 +23,10 @@ modules: ## add missing and remove unused modules
 	go mod tidy
 
 compile: ensure-out-dir ## compiles kube-tmuxp for this platform
-	$(GOBIN) build -o $(APP_EXECUTABLE) ./main.go
+	$(GOBIN) build -ldflags "-X main.version=${BUILD}" -o $(APP_EXECUTABLE) ./main.go
 
 compile-linux: ensure-out-dir ## compiles kube-tmuxp for linux
-	GOOS=linux GOARCH=amd64 $(GOBIN) build -o $(APP_EXECUTABLE) ./main.go
+	GOOS=linux GOARCH=amd64 $(GOBIN) build -ldflags "-X main.version=${BUILD}" -o $(APP_EXECUTABLE) ./main.go
 
 fmt: ## format go code
 	$(GOBIN) fmt $(SRC_PACKAGES)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var buildVersion string
+
+// SetVersion set the major and minor version
+func SetVersion(version string) {
+	buildVersion = version
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the current version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(buildVersion)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,9 @@ package main
 
 import "github.com/arunvelsriram/kube-tmuxp/cmd"
 
+var version string
+
 func main() {
+	cmd.SetVersion(version)
 	cmd.Execute()
 }


### PR DESCRIPTION
Add subcommand **version** to show the build the version

The version information is automatically inferred using describe the feature of `git`

```sh
git describe --tags --always --dirty
```

and passed on as ldflags when building the application.

```sh
kube-tmuxp version

v0.2.0-5-gde85afd
```